### PR TITLE
Fix #2 -a argument optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin/conceal*
 build/
 .idea
+conceal

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ brew install conceal
 
 ### Add a secret
 
+`$ conceal dockerhub/token`
+
+or
+
 `$ conceal -a dockerhub/token`
 
 To add a secret to Keychain, call `conceal` and use the `-a` argument to pass the account name to add. You will be immediately prompted to provide a secret value in a secure manner.

--- a/main.go
+++ b/main.go
@@ -19,9 +19,14 @@ func main() {
 	flag.Parse()
 
 	// If an account is not given and version is not requested, error
-	if *account == "" && *version == false && *list == false {
+	if flag.Arg(0) == "" && *version == false && *list == false {
 		flag.PrintDefaults()
 		os.Exit(1)
+	}
+
+	// If an account is given but not set using the -a flag, continue
+	if flag.Arg(0) != "" && *account == "" {
+		*account = flag.Arg(0)
 	}
 
 	// If list is requested, return list of accounts with `Summon` label


### PR DESCRIPTION
No longer require `conceal -a account/name` in order to add a secret.

You can now `concea account/name` instead as a short-hand method.