### PR TITLE
Fixes #19 add ability to read value from stdin

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,11 +2,19 @@ package cmd
 
 import (
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 )
 
 var cfgFile string
+
+const stdinErrMsg = "failed to read from stdin."
+
+func isInputFromPipe() bool {
+	stat, _ := os.Stdin.Stat()
+	return (stat.Mode() & os.ModeCharDevice) == 0
+}
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -2,7 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"log"
+	"os"
+	"strings"
 	"syscall"
 
 	"github.com/infamousjoeg/conceal/pkg/conceal/keychain"
@@ -20,6 +23,25 @@ var setCmd = &cobra.Command{
 	$ conceal set aws/access_key_id`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		// Check if input is coming from a pipe
+		if isInputFromPipe() {
+			// Read from pipe
+			byteSecretVal, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				log.Fatalf("%s %s", stdinErrMsg, err)
+			}
+			byteSecretVal = []byte(strings.TrimSuffix(string(byteSecretVal), "\n"))
+
+			// Add secret and secret value to keychain
+			err = keychain.AddSecret(args[0], byteSecretVal)
+			if err != nil {
+				log.Fatalf("%s", err)
+			}
+
+			fmt.Printf("Added %s successfully to keychain.\n", args[0])
+			os.Exit(1)
+		}
+
 		// Get secret value from STDIN
 		fmt.Println("Please enter the secret value: ")
 		byteSecretVal, err := terminal.ReadPassword(int(syscall.Stdin))


### PR DESCRIPTION
Fixes #19 by adding a check for input from stdin via pipe to `conceal set` and `conceal update` commands.  If input being provided via pipe, that will take precedence over asking for input.