### PR TITLE
Fix Windows failing perm test

### DIFF
--- a/internal/migrate/manager_test.go
+++ b/internal/migrate/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -56,7 +57,7 @@ func TestInstallAndList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat installed: %v", err)
 	}
-	if info.Mode().Perm() != 0o755 {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o755 {
 		t.Fatalf("wrong perm %v", info.Mode().Perm())
 	}
 }


### PR DESCRIPTION
## Summary
- avoid enforcing plugin permission test when running on Windows
- format test file

## Testing
- `go vet ./...`
- `go test ./...`
- `golangci-lint run ./...`
- `go test -race ./...`


------
https://chatgpt.com/codex/tasks/task_e_68752ed81ff083288e6ae2a59076e36e